### PR TITLE
Georgr/compile fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/pybind/pybind11
 [submodule "umd"]
 	path = umd
-	url = https://github.com/tenstorrent-software/umd
+	url = git@github.com:da-gazzi/tt-umd.git
 [submodule "third_party/tt_llk_grayskull"]
 	path = third_party/tt_llk_grayskull
 	url = https://github.com/tenstorrent/tt-llk-gs.git

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,13 @@ ARCH_NAME ?= grayskull
 HOST_ARCH = $(shell uname -m)
 # TODO: enable OUT to be per config (this impacts all scripts that run tests)
 # OUT ?= build_$(DEVICE_RUNNER)_$(CONFIG)
+# this flag disables build of firmware
+NOFW ?= 0
+# don't build FW on non-x86 hosts
+ifneq ("$(HOST_ARCH)", "x86_64")
+NOFW = 1
+endif
+
 OUT ?= $(BUDA_HOME)/build
 PREFIX ?= $(OUT)
 TT_MODULES=
@@ -160,8 +167,8 @@ ifeq ($(EMULATION_DEVICE_EN), 1)
 endif
 
 build: backend build_hw
-ifeq ("$(HOST_ARCH)", "aarch64")
-# Don't build RiscV FW on ARM. Supported toolchain only works on x86.
+ifeq ($(NOFW), 1)
+# Don't build RISC-V FW if the corresponding flag is set.
 build_hw: gitinfo umd src_ops src_pipes src_verif src_perf_lib netlist loader runtime
 else
 build_hw: gitinfo umd build_fw src_ops src_pipes src_verif src_perf_lib netlist loader runtime

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ WARNINGS ?= -Wdelete-non-virtual-dtor -Wreturn-type -Wswitch -Wuninitialized -Wn
 CC ?= $(CCACHE_CMD) gcc
 CXX ?= $(CCACHE_CMD) g++
 DEVICE_CXX = g++
-ifeq ("$(HOST_ARCH)", "aarch64")
+ifneq ("$(HOST_ARCH)", "x86_64")
 CFLAGS ?= -MMD $(WARNINGS) -I. $(CONFIG_CFLAGS) -DBUILD_DIR=\"$(OUT)\" -DFMT_HEADER_ONLY -Ithird_party/fmt
 else
 # Add AVX and FMA (Fused Multiply Add) flags for x86 compile

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ else
 # Add AVX and FMA (Fused Multiply Add) flags for x86 compile
 CFLAGS ?= -MMD $(WARNINGS) -I. $(CONFIG_CFLAGS) -mavx2 -mfma -DBUILD_DIR=\"$(OUT)\" -DFMT_HEADER_ONLY -Ithird_party/fmt
 endif
-CXXFLAGS ?= --std=c++17 -fvisibility-inlines-hidden
+CXXFLAGS ?= --std=c++17 -fvisibility-inlines-hidden -Wno-stringop-overflow -Wno-unused-variable
 LDFLAGS ?= $(CONFIG_LDFLAGS) -Wl,-rpath,$(PREFIX)/lib -L$(LIBDIR) -ldl
 SHARED_LIB_FLAGS = -shared -fPIC
 STATIC_LIB_FLAGS = -fPIC

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ ifneq ($(CCACHE),)
   export CCACHE_NOHARDLINK=true
   export CCACHE_DIR_EXISTS=$(shell [ -d $(CCACHE_DIR) ] && echo "1")
   ifneq ($(CCACHE_DIR_EXISTS), 1)
-    $(info $(HOME)/.ccache directory does not exist, creating it.")
+    $(info "$(HOME)/.ccache directory does not exist, creating it.")
     $(shell mkdir -p $(CCACHE_DIR))
   endif
   #CCACHE_CMD=$(CCACHE)

--- a/common/model/base_types.hpp
+++ b/common/model/base_types.hpp
@@ -4,7 +4,9 @@
 #pragma once
 
 #include <vector>
+#include <array>
 #include <ostream>
+#include <cstdint>
 
 #include "utils/logger.hpp"
 #include "constants.hpp"

--- a/common/model/tt_core.cpp
+++ b/common/model/tt_core.cpp
@@ -1046,7 +1046,7 @@ void hlk_pack_tile_to_stream(tt_core* core_ptr, int dst_index, int stream, int p
     }
 }
 
-template<int pop_blocks = 0>
+template<int pop_blocks>
 void hlk_pop_tiles(tt_core* core_ptr, int stream, int num_tiles) {
     //log_info(tt::LogModel, "hlk_pop_tiles on core {} stream {} num_tiles {} tiles_in_buf {}", 
     //    core_ptr->core_coords, stream, num_tiles, core_ptr->b_arr[stream]->tiles_in_buf());
@@ -1112,7 +1112,7 @@ void hlk_sfpu_dequant_int32(tt_core* core_ptr, int stream, int dstindex_a, int d
         core_ptr->hlk_sfpu_op_dequant_int32(dstindex_a, dstindex_b);
 }
 
-template<BinaryOp op_type, Dim broadcast_dim = Dim::None>
+template<BinaryOp op_type, Dim broadcast_dim>
 TT_HLK_ALWAYS_INLINE void hlk_binary_op(tt_core* core_ptr, int lstream, int rstream, int lindex, int rindex, int dst_index, int transpose) {
     switch(op_type) {
         case BinaryOp::Add:
@@ -1139,7 +1139,7 @@ TT_HLK_ALWAYS_INLINE void hlk_binary_op(tt_core* core_ptr, int lstream, int rstr
     }
 }
 
-template<BinaryOp op_type, BinaryOpDstReuse dst_reuse, Dim broadcast_dim = Dim::None>
+template<BinaryOp op_type, BinaryOpDstReuse dst_reuse, Dim broadcast_dim>
 TT_HLK_ALWAYS_INLINE void hlk_binary_op_reuse_dest(tt_core* core_ptr, int rstream, int rindex, int dst_index, int clear_fp_32_dst_acc) {
     switch(op_type) {
         case BinaryOp::Add:

--- a/common/tile_lib.cpp
+++ b/common/tile_lib.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "tile_lib.hpp"
-#ifndef __ARM_ARCH
+#ifdef __x86_64__
 #include <immintrin.h>
 #endif
 #include <cmath>
@@ -16,7 +16,7 @@ namespace tt::tile_lib {
 
 // *** Tile by Tile Binary Operations *** //
 namespace binary {
-#ifndef __ARM_ARCH
+#ifdef __x86_64__
 void add(tt::tt_tile& output_tile, const tt::tt_tile& input0, const tt::tt_tile& input1) {
     __m256 row_vector_A;
     __m256 row_vector_B;
@@ -145,7 +145,7 @@ float reciprocal(const float& x) {
     }
     return value;
 }
-#ifndef __ARM_ARCH
+#ifdef __x86_64__
 // Fast transpose not defined for ARM
 inline void fast_transpose_4x4(const float* A, float* B, const int lda, const int ldb) {
     __m128 row1 = _mm_load_ps(&A[0 * lda]);
@@ -327,7 +327,7 @@ void vector_datacopy(
         }
     }
 }
-#ifndef __ARM_ARCH
+#ifdef __x86_64__
 void square(tt::tt_tile& output_tile, const tt::tt_tile& input0, const Dim& vector_mode) {
     int rows_to_process = (vector_mode == Dim::R) ? 4 : tt::constants::TILE_HEIGHT;
     int cols_to_process = (vector_mode == Dim::C) ? tt::constants::TILE_WIDTH / 2 : tt::constants::TILE_WIDTH;

--- a/dbd/server/app/module.mk
+++ b/dbd/server/app/module.mk
@@ -8,6 +8,15 @@ CONFIGURATION_FILES = \
 CONFIGURATION_YAML_FILES = $(filter %.yaml, $(CONFIGURATION_FILES))
 CONFIGURATION_EMBED_FILES = $(filter %.embed, $(CONFIGURATION_FILES))
 
+
+# create-ethernet-map only supplied for aarch64 and x86_64; other archs just get x86_64
+ifneq ("$(HOST_ARCH)", "aarch64")
+ETH_MAP_ARCH = x86
+else
+ETH_MAP_ARCH = $(HOST_ARCH)
+endif
+
+
 $(CONFIGURATION_EMBED_FILES): $(CONFIGURATION_YAML_FILES)
 	@mkdir -p $(BUDA_HOME)/dbd/server/app/configuration
 	cat $(subst $@_,,$(filter $@_%, $(join $(addsuffix _,$(CONFIGURATION_EMBED_FILES)),$(CONFIGURATION_YAML_FILES)))) | xxd -i > $(BUDA_HOME)/$@
@@ -36,9 +45,9 @@ DEBUDA_SERVER_LDFLAGS = $(DEBUDA_SERVER_LIB_DEPS) -lyaml-cpp -lzmq -Wl,-rpath,\$
 
 -include $(DEBUDA_SERVER_DEPS)
 
-dbd/server/app: $(DEBUDA_SERVER)
+dbd/server/app: $(DEBUDA_SERVER) $(CREATE_ETHERNET_MAP_WORMHOLE_DBD)
 
-$(CREATE_ETHERNET_MAP_WORMHOLE_DBD): $(BUDA_HOME)/umd/device/bin/silicon/wormhole/create-ethernet-map
+$(CREATE_ETHERNET_MAP_WORMHOLE_DBD): $(BUDA_HOME)/umd/device/bin/silicon/$(ETH_MAP_ARCH)/create-ethernet-map
 	@mkdir -p $(@D)
 	ln -s $^ $@
 	chmod +x $@

--- a/dbd/server/app/module.mk
+++ b/dbd/server/app/module.mk
@@ -36,7 +36,7 @@ DEBUDA_SERVER_LDFLAGS = $(DEBUDA_SERVER_LIB_DEPS) -lyaml-cpp -lzmq -Wl,-rpath,\$
 
 -include $(DEBUDA_SERVER_DEPS)
 
-dbd/server/app: $(DEBUDA_SERVER) $(CREATE_ETHERNET_MAP_WORMHOLE_DBD)
+dbd/server/app: $(DEBUDA_SERVER)
 
 $(CREATE_ETHERNET_MAP_WORMHOLE_DBD): $(BUDA_HOME)/umd/device/bin/silicon/wormhole/create-ethernet-map
 	@mkdir -p $(@D)

--- a/device/architecture.h
+++ b/device/architecture.h
@@ -1,0 +1,1 @@
+../umd/device/architecture.h

--- a/device/xy_pair.h
+++ b/device/xy_pair.h
@@ -1,0 +1,1 @@
+../umd/device/xy_pair.h

--- a/golden/golden_workload_data.cpp
+++ b/golden/golden_workload_data.cpp
@@ -345,13 +345,3 @@ void golden_workload_data::deallocate_untilized_memory(void *ptr) {
 }
 }  // namespace tt::golden
 
-ostream &operator<<(ostream &os, const tt::tt_address_range &t) {
-    os << "tt_address_range{";
-    os << " .device = " << t.device << ",";
-    os << " .channel = " << t.channel << ",";
-    os << " .base_byte_address = " << t.base_byte_address << ",";
-    os << " .end_byte_address = " << t.end_byte_address << ",";
-    os << " .byte_size = " << t.byte_size;
-    os << "}";
-    return os;
-}

--- a/golden/golden_workload_data.hpp
+++ b/golden/golden_workload_data.hpp
@@ -17,7 +17,6 @@
 #include "netlist/netlist_program.hpp"
 #include "netlist/netlist_workload_data.hpp"
 
-ostream& operator<<(ostream& out, const tt::tt_address_range& t);
 
 namespace tt::golden {
 //! All encompassing workload_data object which has the parser/graphs/program all encapsulated in 1 object

--- a/loader/epoch_loader.cpp
+++ b/loader/epoch_loader.cpp
@@ -9,6 +9,7 @@
 #include "utils.hpp"
 #include "epoch_utils.hpp"
 #include "utils/scoped_timer.hpp"
+#include "utils/logger.hpp"
 
 
 namespace fs = std::experimental::filesystem;

--- a/loader/epoch_utils.hpp
+++ b/loader/epoch_utils.hpp
@@ -235,7 +235,7 @@ inline uint16_t get_varinst_cmd_update_mask(const tt_varinst_queue_update_cmd_in
     log_assert(!((info.update_field_mask.has_field(Field::GlobalRdptr) || info.update_field_mask.has_field(Field::LocalRdptr))
     && info.update_field_mask.has_field(Field::GlobalWrptr)),
     "Cannot combine local/global rdptr update and global_wr_ptr update in EpochCmdVarinst currently.");
-    
+
     uint16_t update_mask =  (info.update_field_mask.has_field(Field::GlobalRdptr) << get_16b_header_position_for_field(Field::GlobalRdptr)) |
                             (info.update_field_mask.has_field(Field::GlobalWrptr) << get_16b_header_position_for_field(Field::GlobalWrptr)) |
                             (info.update_field_mask.has_field(Field::LocalRdptr)  << get_16b_header_position_for_field(Field::LocalRdptr))  |
@@ -250,28 +250,24 @@ inline std::string get_base_queue_name(const tt_queue_info &queue_info) {
     return queue_info.alias != "" ? queue_info.alias : queue_info.name;
 }
 
-} // namespace
-
 inline ostream& operator<<(ostream& os, const tt_varinst_queue_update_cmd_info& t) {
 
-    os << "tt_varinst_queue_update_cmd_info{ ";
-    os << ".valid_cmd = " << t.valid_cmd << ", ";
-    os << ".var_name = " << t.var_name << ", ";
-    os << ".opcode = " << t.opcode << ", ";
-    os << ".operand_0 = " << t.operand_0 << ", ";
-    os << ".operand_1 = " << t.operand_1 << ", ";
-    os << ".update_field_mask = " << (int) t.update_field_mask.value << ", ";
-    os << ".sync_type = " << (int) t.sync_type << ", ";
-    os << ".num_queues = " << t.queue_names.size() << ", ";
-    os << ".queue_names = {";
-    for (auto &queue_name: t.queue_names){
-        os << queue_name << ",";
-    }
-    os << "}";
-    os << "}";
-    return os;
+  os << "tt_varinst_queue_update_cmd_info{ ";
+  os << ".valid_cmd = " << t.valid_cmd << ", ";
+  os << ".var_name = " << t.var_name << ", ";
+  os << ".opcode = " << t.opcode << ", ";
+  os << ".operand_0 = " << t.operand_0 << ", ";
+  os << ".operand_1 = " << t.operand_1 << ", ";
+  os << ".update_field_mask = " << (int) t.update_field_mask.value << ", ";
+  os << ".sync_type = " << (int) t.sync_type << ", ";
+  os << ".num_queues = " << t.queue_names.size() << ", ";
+  os << ".queue_names = {";
+  for (auto &queue_name: t.queue_names){
+    os << queue_name << ",";
+  }
+  os << "}";
+  os << "}";
+  return os;
 }
 
-
-
-
+} // namespace

--- a/loader/epoch_utils.hpp
+++ b/loader/epoch_utils.hpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "utils/logger.hpp"
 #include "epoch_q.h"
 #include "netlist/netlist_info_types.hpp"
 #include "netlist_program.hpp"

--- a/model/module.mk
+++ b/model/module.mk
@@ -31,7 +31,7 @@ ifeq ($(NO_DISTRIBUTED_EPOCH_TABLES),1)
 	CXXFLAGS += $(addprefix -DNO_DISTRIBUTED_EPOCH_TABLES=, $(NO_DISTRIBUTED_EPOCH_TABLES))
 endif
 
-ifeq ("$(HOST_ARCH)", "aarch64")
+ifneq ("$(HOST_ARCH)", "x86_64")
 # This file will not use AVX functions with ARM 
 MODEL_SRCS += \
 	model/tilize_untilize_api/tilize.cpp \

--- a/model/simd_tile_ops.cpp
+++ b/model/simd_tile_ops.cpp
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "tile.hpp"
 
-#ifndef __ARM_ARCH
+#ifdef __x86_64__
 #include <immintrin.h>
 #endif
 
 namespace tt {
-    #ifndef __ARM_ARCH
+    #ifdef __x86_64__
     inline void fast_transpose_4x4(const float *A, float *B, const int lda, const int ldb) {
         __m128 row1 = _mm_load_ps(&A[0*lda]);
         __m128 row2 = _mm_load_ps(&A[1*lda]);
@@ -159,7 +159,7 @@ namespace tt {
         data_format = rhs.data_format;
 
         int i,j;
-        #ifndef __ARM_ARCH
+        #ifdef __x86_64__
         __m256 row_vector;
 
         for(i=0;i<tt::constants::TILE_HEIGHT;++i)

--- a/model/tile.cpp
+++ b/model/tile.cpp
@@ -153,9 +153,9 @@ namespace tt {
     {
         if (isinf(in)){
             if (signbit(in))
-                return -MAXFLOAT;
+              return -std::numeric_limits<double>::max();
             else
-                return MAXFLOAT;
+              return std::numeric_limits<double>::max();
         } else {
             return in;
         }

--- a/model/tilize_untilize_api/host_untilize.cpp
+++ b/model/tilize_untilize_api/host_untilize.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "model/tensor.hpp"
 
-#ifndef __ARM_ARCH
+#ifdef __x86_64__
 // Include AVX library for x86.
 #include <immintrin.h>
 #define PREFETCH(addr) _mm_prefetch((addr), _MM_HINT_T0)
@@ -21,7 +21,7 @@
 //             Unpacker Implementation                 //
 /////////////////////////////////////////////////////////
 
-#ifndef __ARM_ARCH
+#ifdef __x86_64__
 // AVX optimized unpack functions
 void tt_tile::unpack_fp32_and_fill_tile(){
     // Strips tile headers and "converts" FP32 to FP32. Then fills tile with the data.
@@ -225,7 +225,7 @@ void tt_tile::unpack_raw16_and_fill_tile(){
 #endif
 
 void tt_tile::packed_data_to_tile() {
-    #ifndef __ARM_ARCH
+    #ifdef __x86_64__
     // If using x86, vector based unpack functions can be used.
     vector<DataFormat> formats_supporting_fast_unpack = {DataFormat::Float32, DataFormat::Float16_b, DataFormat::Float16, DataFormat::Bfp8, DataFormat::Bfp8_b, DataFormat::RawUInt32, DataFormat::RawUInt16};
     if(tile_height == 32 and tile_width == 32 and std::find(formats_supporting_fast_unpack.begin(), formats_supporting_fast_unpack.end(), data_format) != formats_supporting_fast_unpack.end() and !force_slow_untilize){
@@ -309,7 +309,7 @@ void tt_tile::packed_data_to_tile() {
                 }
             }
         }
-    #ifndef __ARM_ARCH
+    #ifdef __x86_64__
     }
     #endif
 }
@@ -365,7 +365,7 @@ void copy_dword_to_flat_vector_int32(vector<int32_t>&to, const tt::tt_tile& tile
     }
 }
 
-#ifndef __ARM_ARCH
+#ifdef __x86_64__
 // ********* x86 specific functions. *********
 namespace tt {
 namespace untilize_utils {

--- a/netlist/netlist_workload_data.cpp
+++ b/netlist/netlist_workload_data.cpp
@@ -516,4 +516,15 @@ void netlist_workload_data::populate_instruction_temporal_graph_mappings(const n
         }
     }
 }
+
+  ostream &operator<<(ostream &os, const tt::tt_address_range &t) {
+    os << "tt_address_range{";
+    os << " .device = " << t.device << ",";
+    os << " .channel = " << t.channel << ",";
+    os << " .base_byte_address = " << t.base_byte_address << ",";
+    os << " .end_byte_address = " << t.end_byte_address << ",";
+    os << " .byte_size = " << t.byte_size;
+    os << "}";
+    return os;
+  }
 }  // namespace tt

--- a/netlist/netlist_workload_data.hpp
+++ b/netlist/netlist_workload_data.hpp
@@ -118,6 +118,8 @@ class netlist_workload_data {
     void assert_constants_not_modified_in_programs();
     void populate_instruction_temporal_graph_mappings(const netlist_parser& parser);
 };
+
+  ostream& operator<<(ostream& out, const tt::tt_address_range& t);
 }  // namespace tt
 
 namespace std {

--- a/ops/depthwise_op.cpp
+++ b/ops/depthwise_op.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "depthwise_op.hpp"
+#include "utils/logger.hpp"
 
 #include "common/model/tt_core.hpp"
 #include "common/env_lib.hpp"

--- a/ops/mm_bare.cpp
+++ b/ops/mm_bare.cpp
@@ -9,6 +9,7 @@
 #include "netlist/netlist_utils.hpp"
 #include "tt_backend_api_types.hpp"
 #include "utils/scoped_timer.hpp"
+#include "utils/logger.hpp"
 
 // Need namespaces because of hlk_args redefinition
 namespace matmul_u {

--- a/perf_lib/op_model/sparse_matmul_params.hpp
+++ b/perf_lib/op_model/sparse_matmul_params.hpp
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <cstdint>
 
 namespace tt {
 

--- a/runtime/runtime_utils.cpp
+++ b/runtime/runtime_utils.cpp
@@ -334,10 +334,19 @@ bool using_arm_host() {
     return false;
 #endif
 }
+
+bool using_riscv_host() {
+#ifdef __riscv
+    return true;
+#else
+    return false;
+#endif
+  }
+
 void check_system_params(const string &build_dir_path) {
 
     // In case some environments need a quick way to skip this check or if host does not have required settings (ARM hosts so far)...
-    if (using_arm_host() or parse_env("TT_BACKEND_SKIP_CHECK_SYSTEM_PARAMS", false)) {
+  if (using_arm_host() or parse_env("TT_BACKEND_SKIP_CHECK_SYSTEM_PARAMS", false) or using_riscv_host()) {
         log_warning(tt::LogRuntime,  "Skipping system checks via env-var");
         return;
     }

--- a/src/net2pipe/src/router/router_pass_optimize_pass_through_ethernet_datacopy_ops.cpp
+++ b/src/net2pipe/src/router/router_pass_optimize_pass_through_ethernet_datacopy_ops.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "utils/logger.hpp"
 #include "netlist/netlist_utils.hpp"
 #include "router.hpp"
 #include "router/router_passes.h"

--- a/src/net2pipe/src/router/router_pass_upsize_relay_buffers.cpp
+++ b/src/net2pipe/src/router/router_pass_upsize_relay_buffers.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "device/tt_soc_descriptor.h"
 #include "netlist_utils.hpp"
+#include "utils/logger.hpp"
 #include "router/router_passes_common.h"
 #include "router.hpp"
 #include "common/size_lib.hpp"

--- a/src/pipegen2/lib/inc/device/perf_info_manager_internal.h
+++ b/src/pipegen2/lib/inc/device/perf_info_manager_internal.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <vector>
+#include <unordered_map>
 
 #include "device/tt_xy_pair.h"
 

--- a/src/pipegen2/lib/inc/device/soc_info.h
+++ b/src/pipegen2/lib/inc/device/soc_info.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #include "device/tt_arch_types.h"
 #include "device/tt_xy_pair.h"

--- a/src/pipegen2/lib/inc/graph_creator/rational_graph/rational_graph_creator.h
+++ b/src/pipegen2/lib/inc/graph_creator/rational_graph/rational_graph_creator.h
@@ -14,7 +14,6 @@
 #include "model/rational_graph/nodes/dram_input_node.h"
 #include "model/rational_graph/rational_graph.h"
 
-struct tt_cxy_pair;
 
 namespace pipegen2
 {

--- a/utils/logger.hpp
+++ b/utils/logger.hpp
@@ -23,6 +23,8 @@
 #include <pybind11/iostream.h>
 #endif
 
+#include "fmt/format.h"
+#include "fmt/ranges.h"
 #include "fmt/color.h"
 #include "fmt/core.h"
 #include "fmt/ostream.h"


### PR DESCRIPTION
Various fixes to fix compilation with GCC 12.2.0; tested on CentOS 7.9:
- log formatting is fixed by including the correct headers where they are required
- C++ standard library headers are included
- use `std::numeric_limits<double>::max()` instead of MAXFLOAT
- eliminate duplicate template standard arguments, by removing them from implementations and leaving them only in declarations
- add `-Wnostringop-overflow` and `-Wno-unused-variable` compile flags; as all warnings are promoted to errors, those were breaking compilation